### PR TITLE
Fix severity ordering, allow non-clippy lints, use short-form args

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -62,17 +62,14 @@ impl CrankyConfig {
 
     pub(crate) fn extra_right_args(&self) -> Vec<String> {
         let mut args = Vec::new();
-        for lint in &self.allow {
-            args.push("-A".to_string());
-            args.push(format!("clippy::{}", lint));
+        for lint in &self.deny {
+            args.push(format!("-D{lint}"));
         }
         for lint in &self.warn {
-            args.push("--warn".to_string());
-            args.push(format!("clippy::{}", lint));
+            args.push(format!("-W{lint}"));
         }
-        for lint in &self.deny {
-            args.push("-D".to_string());
-            args.push(format!("clippy::{}", lint));
+        for lint in &self.allow {
+            args.push(format!("-A{lint}"));
         }
         args
     }


### PR DESCRIPTION
wrt severity ordering, the `allow` section would do nothing if the warn/deny section was smth like `clippy::all`

all lints would have to be specified as `clippy::xxxx` but otherwise you need special-case handling if you want to configure non-clippy lints